### PR TITLE
Continue event sourcing implementation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,14 +25,17 @@ class UsersController < ApplicationController
   # POST /users.json
   def create
     @user = User.new(user_params)
+    command = Commands::Users::Create.new(description: @user.description, name: @user.name)
 
     respond_to do |format|
-      if @user.save
+      if command.valid?
+        command.call
         format.html { redirect_to @user, notice: 'User was successfully created.' }
         format.json { render :show, status: :created, location: @user }
       else
+        @user.errors.merge!(command.errors)
         format.html { render :new }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
+        format.json { render json: command.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -40,11 +43,16 @@ class UsersController < ApplicationController
   # PATCH/PUT /users/1
   # PATCH/PUT /users/1.json
   def update
+    @user.assign_attributes(user_params)
+    command = Commands::Users::Update.new(active: true, description: @user.description, id: @user.id, name: @user.name, visible: true)
+
     respond_to do |format|
-      if @user.update(user_params)
+      if command.valid?
+        command.call
         format.html { redirect_to @user, notice: 'User was successfully updated.' }
         format.json { render :show, status: :ok, location: @user }
       else
+        @user.errors.merge!(command.errors)
         format.html { render :edit }
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end

--- a/app/event/base.rb
+++ b/app/event/base.rb
@@ -1,7 +1,0 @@
-module Event
-  class Base
-    def apply(aggregate)
-      raise "Not implemented"
-    end
-  end
-end

--- a/app/event/user/registered.rb
+++ b/app/event/user/registered.rb
@@ -1,9 +1,0 @@
-module Event
-  module User
-    class Registered < Event::Base
-      def apply(aggregate)
-
-      end
-    end
-  end
-end

--- a/app/jobs/reactor_job.rb
+++ b/app/jobs/reactor_job.rb
@@ -1,0 +1,7 @@
+class ReactorJob < ApplicationJob
+  def perform(event, reactor_class)
+    reactor = reactor_class.constantize
+
+    reactor.call(event)
+  end
+end

--- a/app/models/commands/users/create.rb
+++ b/app/models/commands/users/create.rb
@@ -1,0 +1,21 @@
+module Commands
+  module Users
+    class Create
+      include Lib::Command
+
+      attributes :description, :name
+
+      validates :description, presence: true, length: { minimum: 10 }
+      validates :name, presence: true, length: { minimum: 5 }
+
+      private def build_event
+        Events::Users::Created.new(
+          active: true,
+          description: description,
+          name: name,
+          visible: true,
+        )
+      end
+    end
+  end
+end

--- a/app/models/commands/users/update.rb
+++ b/app/models/commands/users/update.rb
@@ -1,0 +1,24 @@
+module Commands
+  module Users
+    class Update
+      include Lib::Command
+
+      attributes :active, :description, :id, :name, :visible
+
+      validates :id, presence: true
+      validates :active, inclusion: { in: [true, false] }
+      validates :name, presence: true, length: { minimum: 5 }
+      validates :visible, inclusion: { in: [true, false] }
+
+      private def build_event
+        Events::Users::Updated.new(
+          active: active,
+          description: description,
+          id: id,
+          name: name,
+          visible: visible,
+        )
+      end
+    end
+  end
+end

--- a/app/models/events/dispatcher.rb
+++ b/app/models/events/dispatcher.rb
@@ -1,0 +1,6 @@
+# Subscribes Reactors to Events.
+# * `trigger` will run the Reactor synchronously
+# * `async` will queue up a ReactorJob to run the Reactor
+class Events::Dispatcher < Lib::EventDispatcher
+  on Events::Users::Created, trigger: Reactors::Users::SendGettingStartedEmail
+end

--- a/app/models/events/users/base_event.rb
+++ b/app/models/events/users/base_event.rb
@@ -1,0 +1,9 @@
+module Events
+  module Users
+    class BaseEvent < Lib::BaseEvent
+      self.table_name = :user_events
+
+      belongs_to :user, class_name: "::User", autosave: false
+    end
+  end
+end

--- a/app/models/events/users/created.rb
+++ b/app/models/events/users/created.rb
@@ -1,0 +1,18 @@
+module Events
+  module Users
+    class Created < Events::Users::BaseEvent
+      data_attributes :active, :description, :name, :visible
+
+      # @param [User] user
+      # @return [User]
+      def apply(user)
+        user.active = active
+        user.description = description
+        user.name = name
+        user.visible = visible
+
+        user
+      end
+    end
+  end
+end

--- a/app/models/events/users/updated.rb
+++ b/app/models/events/users/updated.rb
@@ -1,0 +1,20 @@
+module Events
+  module Users
+    class Updated < Events::Users::BaseEvent
+      data_attributes :active, :description, :id, :name, :visible
+
+      def apply(user)
+        user.active = active
+        user.description = description
+        user.name = name
+        user.visible = visible
+
+        user
+      end
+
+      private def preset_aggregate
+        self.aggregate ||= ::User.find(id)
+      end
+    end
+  end
+end

--- a/app/models/lib/base_event.rb
+++ b/app/models/lib/base_event.rb
@@ -1,0 +1,115 @@
+# This is the BaseEvent class that all Events inherit from.
+# It takes care of serializing `data` and `metadata` via json
+# It defines setters and accessors for the defined `data_attributes`
+# After create, it calls `apply` to apply changes.
+#
+# Subclasses must define the `apply` method.
+class Lib::BaseEvent < ActiveRecord::Base
+  # serialize :data, JSON
+  # serialize :metadata, JSON
+
+  before_validation :preset_aggregate
+  before_create :apply_and_persist
+  after_create :dispatch
+
+  self.abstract_class = true
+
+  # Apply the event to the aggregate passed in.
+  # Must return the aggregate.
+  def apply(aggregate)
+    raise NotImplementedError
+  end
+
+  after_initialize do
+    self.data ||= {}
+    self.metadata ||= {}
+  end
+
+  # Define attributes to be serialize in the `data` column.
+  # It generates setters and getters for those.
+  #
+  # Example:
+  #
+  # class MyEvent < Lib::BaseEvent
+  #   data_attributes :title, :description, :drop_id
+  # end
+  #
+  # MyEvent.create!(
+  def self.data_attributes(*attrs)
+    @data_attributes ||= []
+
+    attrs.map(&:to_s).each do |attr|
+      @data_attributes << attr unless @data_attributes.include?(attr)
+
+      define_method attr do
+        self.data ||= {}
+        self.data[attr]
+      end
+
+      define_method "#{attr}=" do |arg|
+        self.data ||= {}
+        self.data[attr] = arg
+      end
+    end
+
+    @data_attributes
+  end
+
+  def aggregate=(model)
+    public_send "#{aggregate_name}=", model
+  end
+
+  # Return the aggregate that the event will apply to
+  def aggregate
+    public_send aggregate_name
+  end
+
+  def aggregate_id=(id)
+    public_send "#{aggregate_name}_id=", id
+  end
+
+  def aggregate_id
+    public_send "#{aggregate_name}_id"
+  end
+
+  def build_aggregate
+    public_send "build_#{aggregate_name}"
+  end
+
+  private def preset_aggregate
+    # Build aggregate when the event is creating an aggregate
+    self.aggregate ||= build_aggregate
+  end
+
+  # Apply the transformation to the aggregate and save it.
+  private def apply_and_persist
+    # Lock! (all good, we're in the ActiveRecord callback chain transaction)
+    aggregate.lock! if aggregate.persisted?
+
+    # Apply!
+    self.aggregate = apply(aggregate)
+
+    # Persist!
+    aggregate.save!
+    self.aggregate_id = aggregate.id if aggregate_id.nil?
+  end
+
+  def self.aggregate_name
+    inferred_aggregate = reflect_on_all_associations(:belongs_to).first
+    raise "Events must belong to an aggregate" if inferred_aggregate.nil?
+    inferred_aggregate.name
+  end
+
+  delegate :aggregate_name, to: :class
+
+  # Underscored class name by default. ex: "post/updated"
+  # Used when sending events to the data pipeline
+  def self.event_name
+    self.name.sub("Events::", '').underscore
+  end
+
+  private def dispatch
+    Events::Dispatcher.dispatch(self)
+  end
+end
+

--- a/app/models/lib/command.rb
+++ b/app/models/lib/command.rb
@@ -1,0 +1,105 @@
+# The Base command mixin that commands include.
+#
+# A Command has the following public api.
+#
+# ```
+#   MyCommand.call(user: ..., post: ...) # shorthand to initialize, validate and execute the command
+#   command = MyCommand.new(user: ..., post: ...)
+#   command.valid? # true or false
+#   command.errors # +> <ActiveModel::Errors ... >
+#   command.call # validate and execute the command
+# ```
+#
+# `call` will raise an `ActiveRecord::RecordInvalid` error if it fails validations.
+#
+# Commands including the `Command::Base` mixin must:
+# * list the attributes the command takes
+# * implement `build_event` which returns a non-persisted event or nil for noop.
+#
+# Ex:
+#
+# ```
+#   class MyCommand
+#     include Command
+#
+#     attributes :user, :post
+#
+#     def build_event
+#       Event.new(...)
+#     end
+#   end
+# ```
+module Lib
+  module Command
+    extend ActiveSupport::Concern
+
+    included do
+      include ActiveModel::Validations
+    end
+
+    class_methods do
+      # Run validations and persist the event.
+      #
+      # On success: returns the event
+      # On noop: returns nil
+      # On failure: raise an ActiveRecord::RecordInvalid error
+      def call(*args)
+        new(*args).call
+      end
+
+      # Define the attributes.
+      # They are set when initializing the command as keyword arguments and
+      # are all accessible as getter methods.
+      #
+      # ex: `attributes :post, :user, :ability`
+      def attributes(*args)
+        attr_reader(*args)
+
+        initialize_method_arguments = args.map { |arg| "#{arg}:" }.join(', ')
+        initialize_method_body = args.map { |arg| "@#{arg} = #{arg}" }.join(";")
+
+        class_eval <<~CODE
+          def initialize(#{initialize_method_arguments})
+            #{initialize_method_body}
+            after_initialize
+          end
+        CODE
+      end
+    end
+
+    def call
+      return nil if event.nil?
+      raise "The event should not be persisted at this stage!" if event.persisted?
+
+      validate!
+      execute!
+
+      event
+    end
+
+    def validate!
+      valid? || raise(ActiveRecord::RecordInvalid, self)
+    end
+
+    # A new record or nil if noop
+    def event
+      @event ||= build_event
+    end
+
+    # Save the event. Should not be overwritten by the command as side effects
+    # should be implemented via Reactors triggering other Events.
+    private def execute!
+      event.save!
+    end
+
+    # Returns a new event record or nil if noop
+    private def build_event
+      raise NotImplementedError
+    end
+
+    # Hook to set default values
+    private def after_initialize
+      # noop
+    end
+  end
+end

--- a/app/models/lib/event_dispatcher.rb
+++ b/app/models/lib/event_dispatcher.rb
@@ -1,0 +1,78 @@
+# Dispatcher implementation used by Events::Dispatcher.
+class Lib::EventDispatcher
+  # Register Reactors to Events.
+  # * Reactors registered with `trigger` will be triggered synchronously
+  # * Reactors registered with `async` will be triggered asynchronously via a Sidekiq Job
+  #
+  # Example:
+  #
+  #   on BaseEvent, trigger: LogEvent, async: TrackEvent
+  #   on PledgeCancelled, PaymentFailed, async: [NotifyAdmin, CreateTask]
+  #   on [PledgeCancelled, PaymentFailed], async: [NotifyAdmin, CreateTask]
+  #
+  def self.on(*events, trigger: [], async: [])
+    rules.register(events: events.flatten, sync: Array(trigger), async: Array(async))
+  end
+
+  # Dispatches events to matching Reactors once.
+  # Called by all events after they are created.
+  def self.dispatch(event)
+    reactors = rules.for(event)
+    reactors.sync.each { |reactor| reactor.call(event) }
+    reactors.async.each { |reactor| ReactorJob.perform_later(event, reactor.to_s) }
+  end
+
+  def self.rules
+    @rules ||= RuleSet.new
+  end
+
+  class RuleSet
+    def initialize
+      @rules ||= Hash.new { |h, k| h[k] = ReactorSet.new }
+    end
+
+    # Register events with their sync and async Reactors
+    def register(events:, sync:, async:)
+      events.each do |event|
+        @rules[event].add_sync sync
+        @rules[event].add_async async
+      end
+    end
+
+    # Return a ReactorSet containing all Reactors matching an Event
+    def for(event)
+      reactors = ReactorSet.new
+
+      @rules.each do |event_class, rule|
+        # Match event by class including ancestors. e.g. All events match a role for BaseEvent.
+        if event.is_a?(event_class)
+          reactors.add_sync rule.sync
+          reactors.add_async rule.async
+        end
+      end
+
+      reactors
+    end
+  end
+
+  # Contains sync and async reactors. Used to:
+  # * store reactors via Rules#register
+  # * return a set of matching reactors with Rules#for
+  class ReactorSet
+    attr_reader :sync, :async
+
+    def initialize
+      @sync = Set.new
+      @async = Set.new
+    end
+
+    def add_sync(reactors)
+      @sync += reactors
+    end
+
+    def add_async(reactors)
+      @async += reactors
+    end
+  end
+end
+

--- a/app/models/reactors/users/send_getting_started_email.rb
+++ b/app/models/reactors/users/send_getting_started_email.rb
@@ -1,0 +1,12 @@
+module Reactors
+  module Users
+    class SendGettingStartedEmail
+      def self.call(event)
+        user = event.user
+        name = event.name
+
+        puts "Reacting to event: #{name}, on model User ID: #{user.id}"
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,3 @@
 class User < ApplicationRecord
-  def readonly?
-    true
-  end
+  has_many :events, class_name: "Events::Users::BaseEvent"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :users
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  root "users#index"
 end

--- a/db/migrate/20180927081258_add_user_events.rb
+++ b/db/migrate/20180927081258_add_user_events.rb
@@ -1,11 +1,14 @@
 class AddUserEvents < ActiveRecord::Migration[5.2]
   def change
     create_table :user_events do |t|
-      t.integer :user_id, null: false
-      t.jsonb :data, null: false
-      t.datetime :created_at, null: false
-    end
+      t.string :type, null: false
 
-    add_foreign_key :user_events, :users
+      t.jsonb :data, null: false
+      t.jsonb :metadata, null: false
+
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,9 +16,13 @@ ActiveRecord::Schema.define(version: 2018_09_27_081258) do
   enable_extension "plpgsql"
 
   create_table "user_events", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.string "type", null: false
     t.jsonb "data", null: false
+    t.jsonb "metadata", null: false
+    t.bigint "user_id"
     t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_events_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
This PR is a continuation of the user event source example implementation.

While coding this, a couple of questions came up:

- (library) The `metadata` field almost serves as an extra annotation from developers? At their example, it seems they use for finding associations (e.g.: `metadata: { notification_id: 33456 }`)
- (database) Using Postgres' JSONB, we can safely remove the `serialize` methods from `app/models/lib/base_event.rb`
- (database) There's a strange scope called `recent_first` at the base event model. It seems they had MySQL limitations. This could disappear as well
- (commands) Default values for key arguments do not seem to exist. Could be a bit boring to fill them. Not sure if using kwargs for commands is a good idea. Probably hash arguments flexibility suites more in this case
    - This is clearly visible at this PR's controller, where dynamically setting keyword arguments will make any IDE (e.g. RubyMine) not understand where the key arguments are coming from, and assume that the method signature is wrong
- (note) If we rename events, we'll need to manually update all base event table `type`
    - This was described at the "Challenges" part of Kickstarter's article