### PR TITLE
Implementation changes

### DIFF
--- a/app/models/events/users/base_event.rb
+++ b/app/models/events/users/base_event.rb
@@ -4,6 +4,10 @@ module Events
       self.table_name = :user_events
 
       belongs_to :user, class_name: "::User", autosave: false
+
+      def self.aggregate_name
+        :user
+      end
     end
   end
 end

--- a/app/models/lib/base_event.rb
+++ b/app/models/lib/base_event.rb
@@ -99,12 +99,6 @@ class Lib::BaseEvent < ActiveRecord::Base
 
   delegate :aggregate_name, to: :class
 
-  # Underscored class name by default. ex: "post/updated"
-  # Used when sending events to the data pipeline
-  def self.event_name
-    self.name.sub("Events::", '').underscore
-  end
-
   private def dispatch
     Events::Dispatcher.dispatch(self)
   end

--- a/app/models/lib/base_event.rb
+++ b/app/models/lib/base_event.rb
@@ -5,9 +5,6 @@
 #
 # Subclasses must define the `apply` method.
 class Lib::BaseEvent < ActiveRecord::Base
-  # serialize :data, JSON
-  # serialize :metadata, JSON
-
   before_validation :preset_aggregate
   before_create :apply_and_persist
   after_create :dispatch

--- a/app/models/lib/base_event.rb
+++ b/app/models/lib/base_event.rb
@@ -17,12 +17,25 @@ class Lib::BaseEvent < ActiveRecord::Base
     raise NotImplementedError
   end
 
-  after_initialize do
-    self.data ||= {}
-    self.metadata ||= {}
+  # Aggregate name the event will belong to
+  # Should be a symbol. Example: `:user`
+  def self.aggregate_name
+    raise NotImplementedError, "Events must belong to an aggregate"
   end
 
-  # Define attributes to be serialize in the `data` column.
+  # Replays the event on any given aggregate
+  # @param [Object] aggregate
+  def replay(aggregate)
+    event_class = self.metadata["klass"].constantize
+    event_class.new(self.data).apply(aggregate)
+  end
+
+  after_initialize do
+    self.data ||= {}
+    self.metadata ||= { klass: self.class.name }
+  end
+
+  # Define attributes to be serialized in the `data` column.
   # It generates setters and getters for those.
   #
   # Example:
@@ -33,11 +46,7 @@ class Lib::BaseEvent < ActiveRecord::Base
   #
   # MyEvent.create!(
   def self.data_attributes(*attrs)
-    @data_attributes ||= []
-
     attrs.map(&:to_s).each do |attr|
-      @data_attributes << attr unless @data_attributes.include?(attr)
-
       define_method attr do
         self.data ||= {}
         self.data[attr]
@@ -48,8 +57,6 @@ class Lib::BaseEvent < ActiveRecord::Base
         self.data[attr] = arg
       end
     end
-
-    @data_attributes
   end
 
   def aggregate=(model)
@@ -89,12 +96,6 @@ class Lib::BaseEvent < ActiveRecord::Base
     # Persist!
     aggregate.save!
     self.aggregate_id = aggregate.id if aggregate_id.nil?
-  end
-
-  def self.aggregate_name
-    inferred_aggregate = reflect_on_all_associations(:belongs_to).first
-    raise "Events must belong to an aggregate" if inferred_aggregate.nil?
-    inferred_aggregate.name
   end
 
   delegate :aggregate_name, to: :class

--- a/app/models/lib/command.rb
+++ b/app/models/lib/command.rb
@@ -35,6 +35,12 @@ module Lib
 
     included do
       include ActiveModel::Validations
+
+      # @param [Hash<Symbol, Object>] args
+      def initialize(args = {})
+        args.each { |key, value| instance_variable_set("@#{key}", value) }
+        after_initialize
+      end
     end
 
     class_methods do
@@ -43,27 +49,17 @@ module Lib
       # On success: returns the event
       # On noop: returns nil
       # On failure: raise an ActiveRecord::RecordInvalid error
-      def call(*args)
-        new(*args).call
+      def call(args = {})
+        new(args).call
       end
 
       # Define the attributes.
-      # They are set when initializing the command as keyword arguments and
+      # They are set when initializing the command as a hash and
       # are all accessible as getter methods.
       #
       # ex: `attributes :post, :user, :ability`
       def attributes(*args)
-        attr_reader(*args)
-
-        initialize_method_arguments = args.map { |arg| "#{arg}:" }.join(', ')
-        initialize_method_body = args.map { |arg| "@#{arg} = #{arg}" }.join(";")
-
-        class_eval <<~CODE
-          def initialize(#{initialize_method_arguments})
-            #{initialize_method_body}
-            after_initialize
-          end
-        CODE
+        attr_accessor(*args)
       end
     end
 

--- a/db/migrate/20180927081258_add_user_events.rb
+++ b/db/migrate/20180927081258_add_user_events.rb
@@ -1,8 +1,6 @@
 class AddUserEvents < ActiveRecord::Migration[5.2]
   def change
     create_table :user_events do |t|
-      t.string :type, null: false
-
       t.jsonb :data, null: false
       t.jsonb :metadata, null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 2018_09_27_081258) do
   enable_extension "plpgsql"
 
   create_table "user_events", force: :cascade do |t|
-    t.string "type", null: false
     t.jsonb "data", null: false
     t.jsonb "metadata", null: false
     t.bigint "user_id"


### PR DESCRIPTION
This PR introduces several changes for the event source library:

- `Lib::BaseEvent`
    - Removed `serialize` attributes
    - `self.aggregate_name` isn't inferred from `ActiveRecord` associations, as it now needs explicit declaration, otherwise, it'll raise a `NotImplementedErrors`
    - STI inference was removed
    - `self.metadata` serialized attribute now has the the `klass` key with the class name value by default. `klass` metadata is used to find the event class
    - `#replay` method was created, allowing to replay the event on any given aggregate and replaying the event. This behaves like the `#apply` method with STI
        - Previously, the `#apply` method had a double role due to STI: when loaded from the database, it would automatically load as persisted event class. Without STI, we need to manually load the class from the metadata
        - This change is arguable, as we could detect if there is a `klass` metadata at the `#apply` method, and still use it as the STI approach. I preferred this way, since it reduces the ambiguity of the `#apply` not being implemented on the base class
    - `@data_attributes` instance class variable was removed from the `self.data_attributes` implementation. Its only use was to detect duplicated declarations on data attributes
    - `self.event_name` method was deleted. It was unused on the library
- `Lib::Command`
    - `self.attributes` now accepts a Hash instead of keyword arguments. This allows using plain Ruby `attr_accessors` and `instance_variable_get` instead of creating methods through meta programming
- `Lib::EventDispatcher`
    - No changes